### PR TITLE
fix deprecated rtrim on null values

### DIFF
--- a/Console/ExportTranslation.php
+++ b/Console/ExportTranslation.php
@@ -130,7 +130,7 @@ class ExportTranslation extends Command
         $localeCode = $input->getOption(self::LOCALE_CODE);
         $destination = $input->getOption(self::OUTPUT_FILE);
         $output->writeln(new Phrase('Start export for %1 locale(s)', [$localeCode]));
-        
+
         try {
             $this->state->setAreaCode(Area::AREA_FRONTEND);
 
@@ -180,7 +180,7 @@ class ExportTranslation extends Command
     {
         $generator = ServiceLocator::getDictionaryGenerator();
         $generator->generate(
-            null,
+            '',
             $this->getPhrasesPath(),
             true
         );


### PR DESCRIPTION
- magento 2.4.4-p2
- php 8.1

command:

```
magento blackbird:translation:export
```

exception:

 Deprecated Functionality: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/setup/src/Magento/Setup/Module/I18n/Dictionary/Options/Resolver.php on line 60